### PR TITLE
HomeKit Issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -448,7 +448,8 @@ class BenQProjector {
             .setCharacteristic(Characteristic.Identifier, x)
             .setCharacteristic(Characteristic.ConfiguredName, inputName)
             .setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED)
-            .setCharacteristic(Characteristic.InputSourceType, Characteristic.InputSourceType.APPLICATION);
+            .setCharacteristic(Characteristic.InputSourceType, Characteristic.InputSourceType.APPLICATION)
+            .setCharacteristic(Characteristic.CurrentVisibilityState, Characteristic.CurrentVisibilityState.SHOWN);
       
           service.addLinkedService(tmpInput);
           this.enabledServices.push(tmpInput);
@@ -498,8 +499,6 @@ class BenQProjector {
         this.tvService
           .setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE);
       
-        this.addSources(this.tvService)
-
         this.tvService
             .getCharacteristic(Characteristic.Active)
             .on('get', this.getPowerState.bind(this))
@@ -522,6 +521,7 @@ class BenQProjector {
         
         this.enabledServices.push(this.tvService);
         this.prepareTvSpeakerService();
+        this.addSources(this.tvService)
         this.getBridgingStateService();
         return this.enabledServices;
     }

--- a/index.js
+++ b/index.js
@@ -513,6 +513,12 @@ class BenQProjector {
         this.tvService
             .getCharacteristic(Characteristic.RemoteKey)
             .on('set', this.remoteKeyPress.bind(this));
+
+        this.tvService
+            .getCharacteristic(Characteristic.PowerModeSelection)
+            .on('set', (newValue, callback) => {
+                this.remoteKeyPress(Characteristic.RemoteKey.INFORMATION, callback);
+            });
         
         this.enabledServices.push(this.tvService);
         this.prepareTvSpeakerService();


### PR DESCRIPTION
Hey,

I had some issues with your plugin and the iOS 13 Beta. The issue was that a tv accessory must have the tv service as first element in the service array. Otherwise the Home app can not handle the accessory and many weird things happen. For example: The beamer turns on or off only by opening the accessory detail screen. Or I couldn't rearrange the accessory in the favourites screen. Or the setting screen of the accessory is completely blank.

All in all a few nasty things happened because of this issue.

With this pull request I have fixed the cause for this.