### PR TITLE
Upgrade serialport and node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "serial"
   ],
   "engines": {
-    "node": "^10.10.0",
+    "node": "^12.16.0",
     "homebridge": "^0.4.46"
   },
   "dependencies": {
     "sequential-task-queue": "^1.2.0",
-    "serialport": "^6.0.4",
+    "serialport": "^8.0.7",
     "backoff": "^2.5.0"
   }
 }


### PR DESCRIPTION
At the moment this homebridge plugin can't be installed, as the dependent serialport version is not compatible with the used node version anymore. Therefore, the serialport version needs to be upgraded.

After quick testing, the plugin seems to be running with the new version out-of-the-box.