### PR TITLE
Added picture mode characteristics & resolved some bugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -311,7 +311,7 @@ class BenQProjector {
 
         this.queue.push(cmd);
         if (callback) {
-          callback(null, this.state);
+          callback(null);
         }
     }
 
@@ -335,7 +335,7 @@ class BenQProjector {
         }
         this.queue.push(cmd);
         if (callback) {
-          callback(null, this.mute);
+          callback(null);
         }
     }
 
@@ -368,7 +368,7 @@ class BenQProjector {
             }
         })
         if (callback) {
-            callback(null, this.volume);
+            callback(null);
         }
     }
 
@@ -429,7 +429,7 @@ class BenQProjector {
         this.log("debug", `Sending setPictureMode ${cmd}`);
         this.queue.push(cmd)
         if (callback) {
-            callback(null, this.pictureMode);
+            callback(null);
         }
     }
 
@@ -441,7 +441,8 @@ class BenQProjector {
             this.queue.push(press);
         } else {
             this.log("error", `Remote button ${button} not supported.`)
-            return
+            if(callback) callback(new Error("Remote button not supported"));
+            return;
         }
         if(callback) callback();
     }

--- a/index.js
+++ b/index.js
@@ -251,7 +251,8 @@ class BenQProjector {
 
     async handleVolResponse(response) {
         if (response.indexOf("*VOL=") > -1) {
-            var vol = Number(response.split('=')[1].split('#'));
+            var index = response.lastIndexOf('=');
+            var vol = Number(response.substr(index+1).split('#')[0]);
             this.log("debug", `Volume is: ${vol}`)
             if (vol) {
                 this.volume = vol;


### PR DESCRIPTION
Hi Solowalker,

Awesome plugin, well done!

I extended it by adding the optional Picture Mode characteristic as well. Intention was to enable some automation and set the BenQ's picture mode setting depending on the daylight/ambient light settings. Unfortunately, the usage is rather limited as this characteristic isn't exposed by Apple's Home app, nor did I find any third party apps that do so (yet).

On the plus side, I did manage to resolve some errors and warnings along the way:
- Make serial port calls synchronous to resolve resource conflicts --> the `this.queue.forEach` loop executes in parallel since `sendCommands()`  is an `async` function. This defeats the whole purpose of having a queue in the first place and causes parallel calls to the serial port. Instead a traditional `for` loop can be used, so that execution of the queue happens sequentially. 
- Fix volume polling --> `handleVolResponse()` didn't split on the correct `=`. At least not in my setup where the original command is echo'd by the projector via the serial connection.
- Fix callback issues --> set handlers should pass only one argument (the error) to the callback functions. Homebridge complains about it. 

Other additions:
- Make handle...Response() functions asynchronous --> minor performance benefit.

Hope you'll find this a welcome addition to the project. Keep up the good work!

Kind regards,

Marcel
